### PR TITLE
[Bug Fix] Including key on key press instead of just value

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -46,7 +46,7 @@ export default async (options) => {
         setIndex(index < choices.length - 1 ? index + 1 : choices.length - 1);
       } else {
         const foundIndex = choices.findIndex((choice) => {
-          const choiceValue = choice.value.toLowerCase();
+          const choiceValue = choice.key ? choice.key.toLowerCase() : choice.value.toLowerCase();
           const keyName = key.name.toLowerCase();
           return choiceValue.startsWith(keyName);
         });


### PR DESCRIPTION
There was a silly mistake on Line 49 where the `key` value isn't used, instead when a key is pressed it will search for a `value ` that starts with the key pressed, which isn't what we want if we specify `key` value.