### PR TITLE
fix: different value with same initial should work

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 # Files to exclude from the package
 node_modules/
 *.md
+playground.mjs

--- a/index.mjs
+++ b/index.mjs
@@ -46,9 +46,9 @@ export default async (options) => {
         setIndex(index < choices.length - 1 ? index + 1 : choices.length - 1);
       } else {
         const foundIndex = choices.findIndex((choice) => {
-          const choiceValue = choice.value.toLowerCase();
+          const choiceKey = choice.key.toLowerCase();
           const keyName = key.name.toLowerCase();
-          return choiceValue.startsWith(keyName);
+          return choiceKey === keyName;
         });
         if (foundIndex !== -1) {
           setIndex(foundIndex);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "inquirer-interactive-prompt",
-  "version": "1.0.0",
+  "name": "inquirer-interactive-list-prompt",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "inquirer-interactive-prompt",
-      "version": "1.0.0",
+      "name": "inquirer-interactive-list-prompt",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^1.0.1",

--- a/playground.mjs
+++ b/playground.mjs
@@ -1,0 +1,16 @@
+import prompt from './index.mjs';
+
+(async () => {
+  const answer = await prompt({
+    message: 'What color should we use:',
+    choices: [
+      { name: 'Gray', value: 'gray', key: 'a' },
+      { name: 'Green', value: 'green', key: 'b' },
+      { name: 'Quit', value: 'quit', key: 'q' },
+    ],
+    renderSelected: choice => `❯ ${choice.name} (${choice.key})`, // optional
+    renderUnselected: choice => `  ${choice.name} (${choice.key})`, // optional
+  });
+
+  console.log(`Selected option: ${answer}`);
+})();


### PR DESCRIPTION
If any choices' value has same initail, the key press won't work.

```js
{
    choices: [
      { name: 'Gray', value: 'gray', key: 'a' },
      { name: 'Green', value: 'green', key: 'b' },
      { name: 'Quit', value: 'quit', key: 'q' },
    ],
}
```

From the example above, value 'gray' and value 'green' has the same initail 'g', but we can't use a same key 'g'. Instead we should use different keys such as 'a' and 'b' etc.

I fix this bug by comparing the 'pressed key' and the 'choice's key'. It works well.